### PR TITLE
Fix use_cache parameter handling in ClientFactory

### DIFF
--- a/openai_test/api/client_factory.py
+++ b/openai_test/api/client_factory.py
@@ -10,13 +10,14 @@ class ClientFactory:
     """
     
     @staticmethod
-    def create_openai_client(api_key=None, mock_client=None):
+    def create_openai_client(api_key=None, mock_client=None, use_cache=True):
         """
         Create OpenAI client.
         
         Args:
             api_key (str, optional): API key. If not provided, will be read from environment.
             mock_client (object, optional): Mock client to use instead of real client.
+            use_cache (bool, optional): Whether to use response caching. Defaults to True.
             
         Returns:
             OpenAIClient: OpenAI client instance or mock
@@ -24,4 +25,4 @@ class ClientFactory:
         if mock_client:
             return mock_client
         
-        return OpenAIClient(api_key=api_key)
+        return OpenAIClient(api_key=api_key, use_cache=use_cache)


### PR DESCRIPTION
## Description

This PR fixes an issue where the `use_cache` parameter was being passed to `ClientFactory.create_openai_client()` but the method did not accept this parameter, causing an error.

## Changes

- Added `use_cache` parameter to `ClientFactory.create_openai_client()` method
- Passed the parameter to the `OpenAIClient` constructor

## Testing

Tested with the basic usage scenario and confirmed the utility now works correctly.