### PR TITLE
Fix APIError initialization missing request parameter

### DIFF
--- a/openai_test/api/openai_client.py
+++ b/openai_test/api/openai_client.py
@@ -177,7 +177,10 @@ class OpenAIClient:
                     prompt_tokens=len(system_prompt) + len(user_prompt),
                     success=False
                 )
-            raise APIError(f"OpenAI API returned an error: {str(e)}")
+            # Create a mock request object to satisfy APIError.__init__ requirements
+            # This fixes the "APIError.__init__() missing 1 required positional argument: 'request'" error
+            mock_request = {"method": "POST", "url": "https://api.openai.com/v1/chat/completions"}
+            raise APIError(f"OpenAI API returned an error: {str(e)}", request=mock_request)
             
         except Exception as e:
             logger.error(f"Unexpected error generating text: {str(e)}")


### PR DESCRIPTION
## Issue Description

When the OpenAI API returns a 403 error with code `unsupported_country_region_territory`, the application encounters two errors:

1. The original 403 error from OpenAI API: `Country, region, or territory not supported`
2. A secondary error: `APIError.__init__() missing 1 required positional argument: 'request'`

The second error occurs because when re-raising the APIError exception, the code doesn't pass the required `request` parameter to the APIError constructor.

## Root Cause Analysis

In the `openai_client.py` file, when catching and re-raising the APIError, the code was not providing the required `request` parameter that the OpenAI SDK expects. This parameter became mandatory in recent versions of the OpenAI SDK.

## Fix

Added a mock request object when re-raising the APIError exception:

```python
# Create a mock request object to satisfy APIError.__init__ requirements
mock_request = {"method": "POST", "url": "https://api.openai.com/v1/chat/completions"}
raise APIError(f"OpenAI API returned an error: {str(e)}", request=mock_request)
```

## Testing

All tests pass successfully after the fix:
- Unit tests for the OpenAI client
- Integration tests for the main module

This fix ensures that when the API returns a 403 error, the application can properly handle it without encountering the secondary initialization error.
